### PR TITLE
Fix async data fetching for dashboards and orders

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -10,8 +10,13 @@ export default function AdminDashboard() {
   const [analytics, setAnalytics] = useState(null);
 
   useEffect(() => {
-    const dataService = DataService.getInstance();
-    setAnalytics(dataService.getAnalytics());
+    const fetchAnalytics = async () => {
+      const dataService = DataService.getInstance();
+      const data = await dataService.getAnalytics();
+      setAnalytics(data);
+    };
+
+    fetchAnalytics();
   }, []);
 
   if (!analytics) {

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -14,8 +14,13 @@ export default function AdminOrdersPage() {
   const [selectedStatus, setSelectedStatus] = useState('all');
 
   useEffect(() => {
-    const dataService = DataService.getInstance();
-    setOrders(dataService.getOrders());
+    const fetchOrders = async () => {
+      const dataService = DataService.getInstance();
+      const data = await dataService.getOrders();
+      setOrders(data);
+    };
+
+    fetchOrders();
   }, []);
 
   const filteredOrders = orders.filter(order => {
@@ -36,10 +41,11 @@ export default function AdminOrdersPage() {
     }
   };
 
-  const handleStatusChange = (orderId: string, newStatus: any) => {
+  const handleStatusChange = async (orderId: string, newStatus: any) => {
     const dataService = DataService.getInstance();
-    dataService.updateOrderStatus(orderId, newStatus);
-    setOrders(dataService.getOrders());
+    await dataService.updateOrderStatus(orderId, newStatus);
+    const updated = await dataService.getOrders();
+    setOrders(updated);
   };
 
   const formatCurrency = (value: number) => {

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -14,8 +14,13 @@ export default function ProductsPage() {
   const [selectedCategory, setSelectedCategory] = useState('all');
 
   useEffect(() => {
-    const dataService = DataService.getInstance();
-    setProducts(dataService.getProducts());
+    const fetchProducts = async () => {
+      const dataService = DataService.getInstance();
+      const data = await dataService.getProducts();
+      setProducts(data);
+    };
+
+    fetchProducts();
   }, []);
 
   const filteredProducts = products.filter(product => {
@@ -36,10 +41,11 @@ export default function ProductsPage() {
     }
   };
 
-  const handleStatusChange = (productId: string, newStatus: any) => {
+  const handleStatusChange = async (productId: string, newStatus: any) => {
     const dataService = DataService.getInstance();
-    dataService.updateProductStatus(productId, newStatus);
-    setProducts(dataService.getProducts());
+    await dataService.updateProductStatus(productId, newStatus);
+    const updated = await dataService.getProducts();
+    setProducts(updated);
   };
 
   return (

--- a/app/buyer/compare/page.tsx
+++ b/app/buyer/compare/page.tsx
@@ -23,17 +23,21 @@ export default function ProductComparePage() {
   const [availableProducts, setAvailableProducts] = useState([]);
 
   useEffect(() => {
-    const dataService = DataService.getInstance();
-    const allProducts = dataService.getProducts().filter(p => p.status === 'active');
-    setAvailableProducts(allProducts);
-    
-    // Load from localStorage if available
-    const saved = localStorage.getItem('compareList');
-    if (saved) {
-      const savedIds = JSON.parse(saved);
-      const savedProducts = allProducts.filter(p => savedIds.includes(p.id));
-      setCompareList(savedProducts);
-    }
+    const fetchProducts = async () => {
+      const dataService = DataService.getInstance();
+      const allProducts = (await dataService.getProducts()).filter(p => p.status === 'active');
+      setAvailableProducts(allProducts);
+
+      // Load from localStorage if available
+      const saved = localStorage.getItem('compareList');
+      if (saved) {
+        const savedIds = JSON.parse(saved);
+        const savedProducts = allProducts.filter(p => savedIds.includes(p.id));
+        setCompareList(savedProducts);
+      }
+    };
+
+    fetchProducts();
   }, []);
 
   useEffect(() => {

--- a/app/buyer/orders/page.tsx
+++ b/app/buyer/orders/page.tsx
@@ -24,13 +24,18 @@ export default function BuyerOrdersPage() {
   const [selectedStatus, setSelectedStatus] = useState('all');
 
   useEffect(() => {
-    const authService = AuthService.getInstance();
-    const dataService = DataService.getInstance();
-    const currentUser = authService.getCurrentUser();
-    
-    if (currentUser) {
-      setOrders(dataService.getOrdersByBuyer(currentUser.id));
-    }
+    const fetchOrders = async () => {
+      const authService = AuthService.getInstance();
+      const dataService = DataService.getInstance();
+      const currentUser = authService.getCurrentUser();
+
+      if (currentUser) {
+        const ord = await dataService.getOrdersByBuyer(currentUser.id);
+        setOrders(ord);
+      }
+    };
+
+    fetchOrders();
   }, []);
 
   const filteredOrders = orders.filter(order => {

--- a/app/vendor/company-profile/page.tsx
+++ b/app/vendor/company-profile/page.tsx
@@ -65,24 +65,28 @@ export default function CompanyProfilePage() {
   ];
 
   useEffect(() => {
-    const authService = AuthService.getInstance();
-    const dataService = DataService.getInstance();
-    const currentUser = authService.getCurrentUser();
-    
-    if (currentUser) {
-      const existingCompany = dataService.getCompanyByVendorId(currentUser.id);
-      if (existingCompany) {
-        setCompany(existingCompany);
-      } else {
-        // Initialize with user data
-        setCompany(prev => ({
-          ...prev,
-          name: currentUser.company || '',
-          phone: currentUser.phone || '',
-          cnpj: currentUser.cnpj || ''
-        }));
+    const fetchCompany = async () => {
+      const authService = AuthService.getInstance();
+      const dataService = DataService.getInstance();
+      const currentUser = authService.getCurrentUser();
+
+      if (currentUser) {
+        const existingCompany = await dataService.getCompanyByVendorId(currentUser.id);
+        if (existingCompany) {
+          setCompany(existingCompany);
+        } else {
+          // Initialize with user data
+          setCompany(prev => ({
+            ...prev,
+            name: currentUser.company || '',
+            phone: currentUser.phone || '',
+            cnpj: currentUser.cnpj || ''
+          }));
+        }
       }
-    }
+    };
+
+    fetchCompany();
   }, []);
 
   const handleInputChange = (field: string, value: any) => {
@@ -151,7 +155,7 @@ export default function CompanyProfilePage() {
         serviceAreas: filteredServiceAreas
       };
 
-      dataService.updateCompany(currentUser.id, companyData);
+      await dataService.updateCompany(currentUser.id, companyData);
       alert('Perfil da empresa atualizado com sucesso!');
     } catch (error) {
       alert('Erro ao atualizar perfil. Tente novamente.');

--- a/app/vendor/dashboard/page.tsx
+++ b/app/vendor/dashboard/page.tsx
@@ -13,15 +13,23 @@ export default function VendorDashboard() {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    const authService = AuthService.getInstance();
-    const dataService = DataService.getInstance();
-    const currentUser = authService.getCurrentUser();
-    
-    if (currentUser) {
-      setUser(currentUser);
-      setProducts(dataService.getProductsByVendor(currentUser.id));
-      setOrders(dataService.getOrdersByVendor(currentUser.id));
-    }
+    const fetchData = async () => {
+      const authService = AuthService.getInstance();
+      const dataService = DataService.getInstance();
+      const currentUser = authService.getCurrentUser();
+
+      if (currentUser) {
+        setUser(currentUser);
+        const [prod, ord] = await Promise.all([
+          dataService.getProductsByVendor(currentUser.id),
+          dataService.getOrdersByVendor(currentUser.id),
+        ]);
+        setProducts(prod);
+        setOrders(ord);
+      }
+    };
+
+    fetchData();
   }, []);
 
   const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);

--- a/app/vendor/orders/page.tsx
+++ b/app/vendor/orders/page.tsx
@@ -28,13 +28,18 @@ export default function VendorOrdersPage() {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    const authService = AuthService.getInstance();
-    const dataService = DataService.getInstance();
-    const currentUser = authService.getCurrentUser();
-    
-    if (currentUser) {
-      setOrders(dataService.getOrdersByVendor(currentUser.id));
-    }
+    const fetchOrders = async () => {
+      const authService = AuthService.getInstance();
+      const dataService = DataService.getInstance();
+      const currentUser = authService.getCurrentUser();
+
+      if (currentUser) {
+        const ord = await dataService.getOrdersByVendor(currentUser.id);
+        setOrders(ord);
+      }
+    };
+
+    fetchOrders();
   }, []);
 
   const filteredOrders = orders.filter(order => {
@@ -77,12 +82,12 @@ export default function VendorOrdersPage() {
     }
   };
 
-  const handleStatusChange = (orderId: string, newStatus: any) => {
+  const handleStatusChange = async (orderId: string, newStatus: any) => {
     const dataService = DataService.getInstance();
-    dataService.updateOrderStatus(orderId, newStatus);
-    
+    await dataService.updateOrderStatus(orderId, newStatus);
+
     // Update local state
-    setOrders(prev => prev.map(order => 
+    setOrders(prev => prev.map(order =>
       order.id === orderId ? { ...order, status: newStatus, updatedAt: new Date() } : order
     ));
   };

--- a/app/vendor/products/page.tsx
+++ b/app/vendor/products/page.tsx
@@ -15,14 +15,19 @@ export default function VendorProductsPage() {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    const authService = AuthService.getInstance();
-    const dataService = DataService.getInstance();
-    const currentUser = authService.getCurrentUser();
-    
-    if (currentUser) {
-      setUser(currentUser);
-      setProducts(dataService.getProductsByVendor(currentUser.id));
-    }
+    const fetchProducts = async () => {
+      const authService = AuthService.getInstance();
+      const dataService = DataService.getInstance();
+      const currentUser = authService.getCurrentUser();
+
+      if (currentUser) {
+        setUser(currentUser);
+        const data = await dataService.getProductsByVendor(currentUser.id);
+        setProducts(data);
+      }
+    };
+
+    fetchProducts();
   }, []);
 
   const filteredProducts = products.filter(product => 


### PR DESCRIPTION
## Summary
- await DataService results before updating state
- update admin dashboards/products/orders
- update vendor dashboards/products/orders/profile
- update buyer compare and orders pages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae72e68e08326a1893ba9bf0d0689